### PR TITLE
Round Air Quality Index Value

### DIFF
--- a/custom_components/iocare/air_quality.py
+++ b/custom_components/iocare/air_quality.py
@@ -46,7 +46,7 @@ class AirMonitor(AirQualityEntity):
     @property
     def air_quality_index(self):
         """Return the Air Quality Index (AQI)."""
-        return self._device.quality["air_quality_index"]
+        return round(int(self._device.quality["air_quality_index"]), 1)
 
     @property
     def particulate_matter_2_5(self):


### PR DESCRIPTION
Current air quality index returns a long decimal value when anything other than "20". This can be problematic when using the air quality index with custom cards such as "purifier card". This change converts the returned air quality index to an integer which is then rounded to 1 decimal place.

Prior to Rounding:
![Purifier Pre-Round](https://user-images.githubusercontent.com/52541649/108776741-c80b5d00-7530-11eb-9fce-40541edfbccd.jpg)


With Rounding:
![Purifier Post-Round](https://user-images.githubusercontent.com/52541649/108776783-d78aa600-7530-11eb-811c-c0ce4c8e6e75.jpg)
