### PR TITLE
Change IOCare to IoCare & update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Coway IOCare
+# Coway IoCare
 Custom component for Home Assistant Core for monitoring and controlling
 Coway / Airmega air purifiers.
 
@@ -8,7 +8,7 @@ Coway / Airmega air purifiers.
 ### With HACS
 1. Open HACS Settings and add this repository (https://github.com/sarahhenkens/home-assistant-iocare)
 as a Custom Repository (use **Integration** as the category).
-2. The `Coway IOCare` page should automatically load (or find it in the HACS Store)
+2. The `Coway IoCare` page should automatically load (or find it in the HACS Store)
 3. Click `Install`
 
 ### Manual
@@ -18,5 +18,5 @@ and place inside your Home Assistant Core installation's `custom_components` dir
 
 ## Setup
 1. Install this integration.
-2. Use Config Flow to configure the integration with your Coway IOCare credentials.
-    * Initiate Config Flow by navigating to Configuration > Integrations > click the "+" button > find "Coway IOCare" (restart Home Assistant and / or clear browser cache if you can't find it)
+2. Use Config Flow to configure the integration with your Coway IoCare credentials.
+    * Initiate Config Flow by navigating to Configuration > Integrations > click the "+" button > find "Coway IoCare" (restart Home Assistant and / or clear browser cache if you can't find it)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 Custom component for Home Assistant Core for monitoring and controlling
 Coway / Airmega air purifiers.
 
+**Breaking Change 2021.4.0**
+
+The recent update of home-assistant-iocare to `2021.4.0` uses a new domain. If you previously installed any version prior to `2021.4.0`, you will need to delete the integration from the integrations page in Home Assistant. Due to the new domain name, previous integrations will fail to work.
+1. Delete your current IOCare Integration from the Home Assistant Integrations page
+   1. If you updated prior to deleting the integration, delete the integration, restart Home Assistant, and proceed to step 4
+2. Update home-assistant-iocare via HACS or manually
+3. Restart Home Assistant
+4. Initiate Config Flow by navigating to Configuration > Integrations > click the "+" button > find "Coway IoCare"
+5. Enter your Coway IoCare credentials
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Coway IoCare
+[![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs) ![LGTM Grade](https://img.shields.io/lgtm/grade/python/github/sarahhenkens/home-assistant-iocare) ![GitHub manifest version (path)](https://img.shields.io/github/manifest-json/v/sarahhenkens/home-assistant-iocare?filename=custom_components%2Fcoway%2Fmanifest.json) ![GitHub all releases](https://img.shields.io/github/downloads/sarahhenkens/home-assistant-iocare/total?color=green)
+
 Custom component for Home Assistant Core for monitoring and controlling
 Coway / Airmega air purifiers.
 

--- a/custom_components/coway/__init__.py
+++ b/custom_components/coway/__init__.py
@@ -1,4 +1,4 @@
-"""Support for Coway IOCare"""
+"""Support for Coway IoCare"""
 import asyncio
 import logging
 import voluptuous as vol
@@ -24,7 +24,7 @@ def setup(hass, config):
 
 
 async def async_setup_entry(hass, config_entry):
-    """Set up IOCare integration from a config entry."""
+    """Set up IoCare integration from a config entry."""
     username = config_entry.data.get(CONF_USERNAME)
     password = config_entry.data.get(CONF_PASSWORD)
 

--- a/custom_components/coway/config_flow.py
+++ b/custom_components/coway/config_flow.py
@@ -18,7 +18,7 @@ class IoCareConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
     def __init__(self):
-        """Initialize IOCare configuration flow"""
+        """Initialize IoCare configuration flow"""
         self.schema = vol.Schema({
             vol.Required(CONF_USERNAME): str,
             vol.Required(CONF_PASSWORD): str
@@ -51,7 +51,7 @@ class IoCareConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await self.hass.async_add_executor_job(client.check_access_token)
 
         except Exception:
-            _LOGGER.error("Unable to connect to IOCare: Failed to Log In")
+            _LOGGER.error("Unable to connect to IoCare: Failed to Log In")
             errors = {"base": "auth_error"}
 
         if errors:

--- a/custom_components/coway/manifest.json
+++ b/custom_components/coway/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "coway",
-  "name": "Coway IOCare",
+  "name": "Coway IoCare",
   "version": "2021.4.0",
   "config_flow": true,
   "requirements": ["git+https://github.com/RobertD502/python-iocare@master#python-iocare==0.1.6"],

--- a/custom_components/coway/strings.json
+++ b/custom_components/coway/strings.json
@@ -1,20 +1,20 @@
 {
   "config": {
-    "title": "Coway IOCare",
+    "title": "Coway IoCare",
     "step": {
       "user": {
-        "title": "Fill in your Coway IOCare credentials",
+        "title": "Fill in your Coway IoCare credentials",
         "data": {
-          "username": "Coway Username",
-          "password": "Coway Password"
+          "username": "IoCare Username",
+          "password": "IoCare Password"
         }
       }
     },
     "error": {
-      "auth_error": "IOCare authentication failed. Are your credentials correct?"
+      "auth_error": "IoCare authentication failed. Are your credentials correct?"
     },
     "abort": {
-      "already_configured": "IOCare is already configured"
+      "already_configured": "IoCare is already configured"
     }
   }
 }

--- a/custom_components/coway/translations/en.json
+++ b/custom_components/coway/translations/en.json
@@ -1,20 +1,20 @@
 {
     "config": {
         "abort": {
-            "already_configured": "IOCare is already configured"
+            "already_configured": "IoCare is already configured"
         },
         "error": {
-            "auth_error": "IOCare authentication failed. Are your credentials correct?"
+            "auth_error": "IoCare authentication failed. Are your credentials correct?"
         },
         "step": {
             "user": {
                 "data": {
-                    "username": "Coway Username",
-                    "password": "Coway Password"
+                    "username": "IoCare Username",
+                    "password": "IoCare Password"
                 },
-                "title": "Fill in your Coway IOCare credentials"
+                "title": "Fill in your Coway IoCare credentials"
             }
         },
-        "title": "Coway IOCare"
+        "title": "Coway IoCare"
     }
 }


### PR DESCRIPTION
Sorry for another PR Sarah! I just noticed Coway uses the IoCare naming format instead of IOCare, so, I wanted to make sure the integration does the same.